### PR TITLE
Fix #16

### DIFF
--- a/HybridFileXfer-Android/app/src/main/AndroidManifest.xml
+++ b/HybridFileXfer-Android/app/src/main/AndroidManifest.xml
@@ -16,6 +16,8 @@
         android:icon="@drawable/logo"
         android:label="@string/app_name"
 
+        android:requestLegacyExternalStorage="true"
+
         android:supportsRtl="true"
         android:theme="@style/Theme.HybridFileXfer"
         tools:targetApi="31">


### PR DESCRIPTION
为了查看异常，尝试将异常数据保存到文件时注意到：
```
 CrashHandler: java.io.FileNotFoundException: /sdcard/crash/2024-05-02-22-11-35-1714659095220.log: open failed: EACCES (Permission denied)
```
参考[Exception 'open failed: EACCES (Permission denied)' on Android](https://stackoverflow.com/questions/8854359/exception-open-failed-eacces-permission-denied-on-android)后所有异常修复。