### PR TITLE
docs(README): 添加 ArchLinux AUR 安装方式并修正许可证链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ v1.2.0新增书签功能。
 
 **Dragonwell JDK** 的许可证原文请参见 [Dragonwell JDK License](https://github.com/dragonwell-project/dragonwell21/blob/master/LICENSE)。
 
-本项目整体使用 **GNU General Public License version 3 (GPL-3.0)**，许可证文件可以在 [LICENSE](./LICENSE) 文件中找到。
+本项目整体使用 **GNU General Public License version 3 (GPL-3.0)**，许可证文件可以在 [LICENSE](./LICENSE.txt) 文件中找到。
 
 ### Dragonwell JDK License
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,24 @@ java -jar HybridFileXfer.jar -c adb
 
 目前仅支持x86 CPU的电脑，虽然Java是跨平台的，但是adb对处理器架构有要求。如果你需要在ARM，RISC-V，龙芯等CPU架构下运行，可以寻找对应处理器架构的adb程序，复制到jar包的同一目录。又或者使用USB网络共享。
 
+### ArchLinux 通过 AUR 安装
+
+> **重要提示：** 
+> 
+> 本项目的 issue 跟踪器 **仅用于** 讨论项目本身的 Bug 和功能请求。
+> **请不要在这里提交任何与 AUR 打包、`PKGBUILD` 语法、`makepkg` 错误或 AUR 助手相关的问题。** 
+> 如果你遇到 AUR 相关问题，请在 AUR **网页上的包评论区** 或向软件包维护者寻求帮助。
+
+本项目已在 [Arch Linux 用户仓库 (AUR)](https://aur.archlinux.org/packages/hybridfilexfer-git) 上发布，你可以使用任何你喜欢的 AUR 助手进行安装，例如：
+```bash
+# 使用 yay
+yay -S hybridfilexfer-git
+
+# 使用 paru
+paru -S hybridfilexfer-git
+```
+安装完成后，你可以通过在终端执行 `HybridFileXfer` 来启动电脑端。
+
 ### Mac电脑
 
 个人没尝试在Mac电脑上运行，但Java跨平台，ADB也有对应Mac版，可自己折腾。


### PR DESCRIPTION
您好！

我是 `hybridfilexfer-git` 软件包的维护者，打包脚本与许可证见：  
https://aur.archlinux.org/cgit/aur.git/tree/?h=hybridfilexfer-git  
说来惭愧，当时说好要接着提交打包脚本的，结果被各种事情拖到现在，实在不好意思！

现在终于完成了：
软件包已经在 Arch Linux 上测试通过，所以想为 README 补充一下 AUR 的安装方式，方便 Arch 用户群。另外顺手修正了 LICENSE 文件链接的一处笔误。

这个工具真的非常实用，帮我省了不少同步文件的时间！感谢您的优秀作品。

再次感谢您在百忙之中抽空审阅，祝一切顺利！

Best regards,
@nlsdt 